### PR TITLE
Updated sample script URL

### DIFF
--- a/src/data/markdown/docs/01 guides/01 Getting started/03 Running k6.md
+++ b/src/data/markdown/docs/01 guides/01 Getting started/03 Running k6.md
@@ -11,11 +11,11 @@ if you prefer using the k6 [Docker image](https://en.wikipedia.org/wiki/Docker_%
 <div class="code-group" data-props='{"labels": ["Mac / prebuilt binary", "Docker image"]}'>
 
 ```shell
-$ k6 run github.com/loadimpact/k6/samples/http_get.js
+$ k6 run https://raw.githubusercontent.com/loadimpact/k6/master/samples/http_get.js
 ```
 
 ```shell
-$ docker run loadimpact/k6 run github.com/loadimpact/k6/samples/http_get.js
+$ docker run loadimpact/k6 run https://raw.githubusercontent.com/loadimpact/k6/master/samples/http_get.js
 ```
 
 </div>


### PR DESCRIPTION
Older URL had no scheme and gave 404 due to GitHub shifting user contents to a separate domain.