### PR TITLE
Pin uuid package in example

### DIFF
--- a/src/data/markdown/docs/05 Examples/01 Examples/10 generating-uuids.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/10 generating-uuids.md
@@ -5,6 +5,9 @@ excerpt: "Scripting example on how to generate UUIDs in your load test."
 
 Scripting example on how to generate UUIDs in your load test.
 
+Note that if you don't need v1 UUIDs, consider using the `uuidv4` function from
+the [k6 JS lib repository](https://jslib.k6.io/).
+
 ## Generate v1 and v4 UUIDs
 Universally unique identifiers are handy in many scenarios, as k6 doesn't have built-in support
 for UUIDs, we'll have to resort to using a Node.js library called [uuid](https://www.npmjs.com/package/uuid)

--- a/src/data/markdown/docs/05 Examples/01 Examples/10 generating-uuids.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/10 generating-uuids.md
@@ -14,18 +14,18 @@ There are a few steps required to make this work:
 
 1. Make sure you have the necessary prerequisites installed:
    [Node.js](https://nodejs.org/en/download/) and [Browserify](http://browserify.org/)
-  
+
 2. Install the `uuid` library:
    <div class="code-group" data-props='{ "labels": [], "lineNumbers": [false] }'>
-    
+
     ```shell
-    $ npm install uuid
+    $ npm install uuid@3.4.0
     ```
 
    </div>
 3. Run it through browserify:
    <div class="code-group" data-props='{ "labels": [], "lineNumbers": [false] }'>
-   
+
    ```shell
    $ browserify node_modules/uuid/index.js -s uuid > uuid.js
    ```
@@ -42,7 +42,7 @@ There are a few steps required to make this work:
    ```
 
    </div>
-   
+
 
 Here's an example generating a v1 and v4 UUID:
 


### PR DESCRIPTION
This is the last version that this example works with. Supporting newer versions would involve [polyfilling `crypto.getRandomValues()`](https://github.com/uuidjs/uuid#getrandomvalues-not-supported), so pinning this is simpler.

Also added a link to the JS lib, which will be easier for most users.

See https://github.com/loadimpact/k6/issues/1482