### PR TITLE
[feature] Cloud APM: sending metrics to APM platforms

### DIFF
--- a/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
+++ b/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
@@ -71,7 +71,7 @@ Make sure to meet the following requirements, otherwise we can't guarantee a wor
 1. You can specify your own custom metrics (defined in your script) to be exported to one or many APM platform(s).
 2. If the APM configuration has errors, e.g. invalid provider, wrong credentials, etc., the test will continue, but the metrics export(s) will be disabled.
 3. If you provide invalid custom metrics to the `export_metrics` field, the test will continue, but the metrics export(s) will not include the invalid custom metric.
-4. Provider name, export_metrics is case-sensitive.
+4. The `provider` (name) and metrics defined in `export_metrics` are case-sensitive.
 
 ## Feature Availability
 

--- a/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
+++ b/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
@@ -14,7 +14,7 @@ Currently, the following platforms are supported:
 | datadog   | <https://www.datadoghq.com> |
 | datadogeu | <https://www.datadoghq.eu>  |
 
-This list will be expanded in the future. Please [contact us](https://io/contact) if you would like an integration that isn't currently listed.
+This list will be expanded in the future. Please [contact us](https://k6.io/contact) if you would like an integration that isn't currently listed.
 
 ## Cloud APM Configuration
 

--- a/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
+++ b/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
@@ -3,7 +3,7 @@ title: 'Cloud APM'
 excerpt: 'How to export metrics from k6 Cloud to APM platforms'
 ---
 
-A new feature has been recently added to the k6 Cloud service, for users to be able to export metrics from a running test on k6 Cloud in near real-time to their preferred [APM](https://en.wikipedia.org/wiki/Application_performance_management) platform(s).
+k6 Cloud platform supports exporting metrics to APM platforms, thereby enabling users to export metrics from a running test in near real-time to their preferred [APM](https://en.wikipedia.org/wiki/Application_performance_management) platform(s).
 
 ## Supported APM Providers
 
@@ -11,25 +11,27 @@ Currently, the following platforms are supported:
 
 | Provider  | URL(s)                      |
 | --------- | --------------------------- |
-| DataDog   | <https://www.datadoghq.com> |
-| DataDogEU | <https://www.datadoghq.eu>  |
+| datadog   | <https://www.datadoghq.com> |
+| datadogeu | <https://www.datadoghq.eu>  |
+
+This list will be expanded in the future. Please [contact us](https://k6.io/contact) if you would like an integration that isn't currently listed.
 
 ## Cloud APM Configuration
 
-For configuring each platform on your load test on k6 Cloud, you should add your desired APM configuration to the [extension options](/using-k6/options#extension-options) section of your load test script. The configuration parameters are as follows:
+For maximum flexibility, the APM export functionality is configured on the test-run level. The required parameters should be specified in `options.ext.loadimpact.apm` (See [extension options](/using-k6/options#extension-options) for more information). The configuration parameters are as follows:
 
-| Name                     | Description                                                                                                                           |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `provider`               | Any APM provider name available in the [supported APM provider](#supported-apm-providers)'s table.                                    |
-| `api_key`                | The `api_key` provided by the APM platforms.                                                                                          |
-| `app_key`                | The `app_key` provided by the APM platforms, if applicable.                                                                           |
-| `export_metrics`         | List of custom metrics to be exported.                                                                                                |
-| `export_default_metrics` | If set, the export will include the default metrics. Default is `true`.                                                               |
-| `resample_rate`          | The rate by which the metrics are resampled and sent to the server. Default is 3 and acceptable values are integers between 1 and 10. |
+| Name                      | Description                                                                                                                                            |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `provider`                | Any APM provider name available in the [supported APM provider](#supported-apm-providers)'s table.                                                     |
+| `api_key`                 | The `api_key` provided by the APM platforms.                                                                                                           |
+| `app_key`                 | The `app_key` provided by the APM platforms, if applicable.                                                                                            |
+| `export_metrics`          | List of custom metrics to be exported.                                                                                                                 |
+| `include_default_metrics` | If set, the export will include the default metrics. Default is `true`.                                                                                |
+| `resample_rate`           | The rate by which the metrics are resampled and sent to the APM provider in seconds. Default is 3 and acceptable values are integers between 1 and 10. |
 
-**Note**: This [guide](https://docs.datadoghq.com/account_management/api-app-keys/) will walk you through creating an `api_key` and an `app_key` on DataDog. Note that the `api_key` and `app_key` for `DataDog` won't work on `DataDogEU`.
+**Note**: This [guide](https://docs.datadoghq.com/account_management/api-app-keys/) will walk you through creating an `api_key` and an `app_key` on DataDog. Note that the `api_key` and `app_key` for `datadog` won't work on `datadogeu`.
 
-The `export_metrics` parameter allows for choosing custom exported metrics. The default set of [metrics](/using-k6/metrics) is as follows. These defaults also match the official k6 Dashboard for DataDog, which you can read more about on [visualization of metrics in DataDog](/results-visualization/datadog#visualize-in-datadog).
+The `export_metrics` parameter allows you to specify custom metrics to be exported to the APM provider. By default, only the basic [metrics](/using-k6/metrics) listed below are exported. These defaults also match the official k6 Dashboard for DataDog, which you can read more about on [visualization of metrics in DataDog](/results-visualization/datadog#visualize-in-datadog).
 
 - k6.data_sent
 - k6.data_received
@@ -40,13 +42,13 @@ The `export_metrics` parameter allows for choosing custom exported metrics. The 
 
 <div class="doc-blockquote" data-props='{"mod": "warning"}'>
 
-If you only want to export custom metrics from your test, you can add those custom metrics you've defined in your script to the `export_metrics` variable and set `export_default_metrics` to `false`. Otherwise, the above mentioned default metrics will be automatically exported.
+A typical use case is to only export custom metrics defined in the script. To do that you should specify the named of your custom metrics in the `export_metrics` parameter, and set `include_default_metrics` to false.
 
 </div>
 
 If you want to export metrics with more granularity, consider using a lower number for the `resample_rate`, like 1.
 
-The `apm` key (inside `ext.loadimpact`) accepts a list of APM configurations (objects). Exporting metrics to APM platforms will be simultaneous and near real-time. Also, there is a 2nd pass (of metrics exports), at the end of each test run, that ensures data reliability and accuracy.
+The `apm` key (inside `ext.loadimpact`) accepts a list of APM configurations (objects). Exporting metrics to APM platforms will be simultaneous and near real-time. Also, there is a 2nd pass (of metrics exports), at the end of each test run, that ensures data reliability and accuracy. Please note that the data exported in real-time may appear incorrect until the test is finished.
 
 ```js
 export let options = {
@@ -54,11 +56,11 @@ export let options = {
     loadimpact: {
       apm: [
           {
-              provider: "DataDog",
+              provider: "datadog",
               api_key: "<DataDog Provided API key>",
               app_key: "<DataDog Provided App key>",
-              export_metrics: ["k6.vus", "my_rate", ...],
-              export_default_metrics: true
+              export_metrics: ["my_rate", "my_gauge", ...],
+              include_default_metrics: true
           },
       ]
     },
@@ -68,10 +70,15 @@ export let options = {
 
 Make sure to meet the following requirements, otherwise we can't guarantee a working metrics export:
 
-1. You can specify your own custom metrics (defined in your script) to be exported to one or many APM platform(s).
-2. If the APM configuration has errors, e.g. invalid provider, wrong credentials, etc., the test will continue, but the metrics export(s) will be disabled.
+1. If you use custom metrics in your script, remember to add them to the `export_metrics` array, otherwise, those metrics won't be automatically exported.
+2. If the APM configuration has errors, (e.g. invalid provider, wrong credentials, etc) the configuration will be ignored, and the test will be executed without the APM functionality.
 3. If you provide invalid custom metrics to the `export_metrics` field, the test will continue, but the metrics export(s) will not include the invalid custom metric.
-4. The `provider` (name) and metrics defined in `export_metrics` are case-sensitive.
+4. The metrics defined in `export_metrics` are case-sensitive.
+
+## Limitations
+
+1. APM data export is supported for tests that are up to 1 hour long. Longer tests are currently not supported.
+2. The data exported in near real-time may appear incorrect, until the test is finished and the 2nd pass export has completed.
 
 ## Feature Availability
 

--- a/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
+++ b/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
@@ -1,0 +1,83 @@
+---
+title: 'Cloud APM'
+excerpt: 'How to export metrics from k6 Cloud to APM platforms'
+---
+
+A new feature has been recently added to the k6 Cloud service, for users to be able to export metrics from a running test on k6 Cloud in near real-time to their preferred [APM](https://en.wikipedia.org/wiki/Application_performance_management) platform(s).
+
+## Supported APM Providers
+
+Currently, the following platforms are supported:
+
+| Provider  | URL(s)                      |
+| --------- | --------------------------- |
+| DataDog   | <https://www.datadoghq.com> |
+| DataDogEU | <https://www.datadoghq.eu>  |
+
+## Cloud APM Configuration
+
+For configuring each platform on your load test on k6 Cloud, you should add your desired APM configuration to the [extension options](/using-k6/options#extension-options) section of your load test script. The configuration parameters are as follows:
+
+| Name                     | Description                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `provider`               | Any APM provider name available in the [supported APM provider](#supported-apm-providers)'s table.                                    |
+| `api_key`                | The `api_key` provided by the APM platforms.                                                                                          |
+| `app_key`                | The `app_key` provided by the APM platforms, if applicable.                                                                           |
+| `export_metrics`         | List of custom metrics to be exported.                                                                                                |
+| `export_default_metrics` | If set, the export will include the default metrics. Default is `true`.                                                               |
+| `resample_rate`          | The rate by which the metrics are resampled and sent to the server. Default is 3 and acceptable values are integers between 1 and 10. |
+
+**Note**: This [guide](https://docs.datadoghq.com/account_management/api-app-keys/) will walk you through creating an `api_key` and an `app_key` on DataDog. Note that the `api_key` and `app_key` for `DataDog` won't work on `DataDogEU`.
+
+The `export_metrics` parameter allows for choosing custom exported metrics. The default set of [metrics](/using-k6/metrics) is as follows. These defaults also match the official k6 Dashboard for DataDog, which you can read more about on [visualization of metrics in DataDog](/results-visualization/datadog#visualize-in-datadog).
+
+- k6.data_sent
+- k6.data_received
+- k6.http_req_duration
+- k6.http_reqs
+- k6.iterations
+- k6.vus
+
+<div class="doc-blockquote" data-props='{"mod": "warning"}'>
+
+If you only want to export custom metrics from your test, you can add those custom metrics you've defined in your script to the `export_metrics` variable and set `export_default_metrics` to `false`. Otherwise, the above mentioned default metrics will be automatically exported.
+
+</div>
+
+If you want to export metrics with more granularity, consider using a lower number for the `resample_rate`, like 1.
+
+The `apm` key (inside `ext.loadimpact`) accepts a list of APM configurations (objects). Exporting metrics to APM platforms will be simultaneous and near real-time. Also, there is a 2nd pass (of metrics exports), at the end of each test run, that ensures data reliability and accuracy.
+
+```js
+export let options = {
+  ext: {
+    loadimpact: {
+      apm: [
+          {
+              provider: "DataDog",
+              api_key: "<DataDog Provided API key>",
+              app_key: "<DataDog Provided App key>",
+              export_metrics: ["k6.vus", "my_rate", ...],
+              export_default_metrics: true
+          },
+      ]
+    },
+  },
+};
+```
+
+Make sure to meet the following requirements, otherwise we can't guarantee a working metrics export:
+
+1. You can specify your own custom metrics (defined in your script) to be exported to one or many APM platform(s).
+2. If the APM configuration has errors, e.g. invalid provider, wrong credentials, etc., the test will continue, but the metrics export(s) will be disabled.
+3. If you provide invalid custom metrics to the `export_metrics` field, the test will continue, but the metrics export(s) will not include the invalid custom metric.
+4. Provider name, export_metrics is case-sensitive.
+
+## Feature Availability
+
+This feature is only available for certain subscriptions:
+
+- Trial
+- Monthly Pro
+- Annual Team/Pro
+- Enterprise

--- a/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
+++ b/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
@@ -14,7 +14,7 @@ Currently, the following platforms are supported:
 | datadog   | <https://www.datadoghq.com> |
 | datadogeu | <https://www.datadoghq.eu>  |
 
-This list will be expanded in the future. Please [contact us](https://k6.io/contact) if you would like an integration that isn't currently listed.
+This list will be expanded in the future. Please [contact us](https://io/contact) if you would like an integration that isn't currently listed.
 
 ## Cloud APM Configuration
 
@@ -25,24 +25,24 @@ For maximum flexibility, the APM export functionality is configured on the test-
 | `provider`                | Any APM provider name available in the [supported APM provider](#supported-apm-providers)'s table.                                                     |
 | `api_key`                 | The `api_key` provided by the APM platforms.                                                                                                           |
 | `app_key`                 | The `app_key` provided by the APM platforms, if applicable.                                                                                            |
-| `export_metrics`          | List of custom metrics to be exported.                                                                                                                 |
+| `metrics`                 | List of built-in and custom metrics to be exported.                                                                                                    |
 | `include_default_metrics` | If set, the export will include the default metrics. Default is `true`.                                                                                |
 | `resample_rate`           | The rate by which the metrics are resampled and sent to the APM provider in seconds. Default is 3 and acceptable values are integers between 1 and 10. |
 
 **Note**: This [guide](https://docs.datadoghq.com/account_management/api-app-keys/) will walk you through creating an `api_key` and an `app_key` on DataDog. Note that the `api_key` and `app_key` for `datadog` won't work on `datadogeu`.
 
-The `export_metrics` parameter allows you to specify custom metrics to be exported to the APM provider. By default, only the basic [metrics](/using-k6/metrics) listed below are exported. These defaults also match the official k6 Dashboard for DataDog, which you can read more about on [visualization of metrics in DataDog](/results-visualization/datadog#visualize-in-datadog).
+The `metrics` parameter allows you to specify built-in and custom metrics to be exported to the APM provider. By default, only the basic [metrics](/using-k6/metrics) listed below are exported. These defaults also match the official k6 Dashboard for DataDog, which you can read more about on [visualization of metrics in DataDog](/results-visualization/datadog#visualize-in-datadog).
 
-- k6.data_sent
-- k6.data_received
-- k6.http_req_duration
-- k6.http_reqs
-- k6.iterations
-- k6.vus
+- data_sent
+- data_received
+- http_req_duration
+- http_reqs
+- iterations
+- vus
 
 <div class="doc-blockquote" data-props='{"mod": "warning"}'>
 
-A typical use case is to only export custom metrics defined in the script. To do that you should specify the named of your custom metrics in the `export_metrics` parameter, and set `include_default_metrics` to false.
+A typical use case is to only export custom metrics defined in the script. To do that you should specify the named of your custom metrics in the `metrics` parameter, and set `include_default_metrics` to false.
 
 </div>
 
@@ -59,7 +59,7 @@ export let options = {
               provider: "datadog",
               api_key: "<DataDog Provided API key>",
               app_key: "<DataDog Provided App key>",
-              export_metrics: ["my_rate", "my_gauge", ...],
+              metrics: ["http_req_sending", "my_rate", "my_gauge", ...],
               include_default_metrics: true
           },
       ]
@@ -70,10 +70,11 @@ export let options = {
 
 Make sure to meet the following requirements, otherwise we can't guarantee a working metrics export:
 
-1. If you use custom metrics in your script, remember to add them to the `export_metrics` array, otherwise, those metrics won't be automatically exported.
-2. If the APM configuration has errors, (e.g. invalid provider, wrong credentials, etc) the configuration will be ignored, and the test will be executed without the APM functionality.
-3. If you provide invalid custom metrics to the `export_metrics` field, the test will continue, but the metrics export(s) will not include the invalid custom metric.
-4. The metrics defined in `export_metrics` are case-sensitive.
+1. If you use custom metrics in your script, remember to add them to the `metrics` array, otherwise, those metrics won't be automatically exported.
+2. If you want to export built-in metrics that are not listed above, you can include them in the `metrics` array.
+3. If the APM configuration has errors, (e.g. invalid provider, wrong credentials, etc) the configuration will be ignored, and the test will be executed without the APM functionality.
+4. If you provide invalid metrics to the `metrics` field, the test will continue, but the metrics export(s) will not include the invalid metric.
+5. The metrics defined in `metrics` are case-sensitive.
 
 ## Limitations
 

--- a/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
+++ b/src/data/markdown/docs/03 cloud/03 Integrations/05 Cloud APM.md
@@ -28,10 +28,11 @@ For maximum flexibility, the APM export functionality is configured on the test-
 | `metrics`                 | List of built-in and custom metrics to be exported.                                                                                                    |
 | `include_default_metrics` | If set, the export will include the default metrics. Default is `true`.                                                                                |
 | `resample_rate`           | The rate by which the metrics are resampled and sent to the APM provider in seconds. Default is 3 and acceptable values are integers between 1 and 10. |
+| `include_test_run_id`     | If set, the `test_run_id` will be exported per each metric as an extra tag. Default is `false`.                                                        |
 
 **Note**: This [guide](https://docs.datadoghq.com/account_management/api-app-keys/) will walk you through creating an `api_key` and an `app_key` on DataDog. Note that the `api_key` and `app_key` for `datadog` won't work on `datadogeu`.
 
-The `metrics` parameter allows you to specify built-in and custom metrics to be exported to the APM provider. By default, only the basic [metrics](/using-k6/metrics) listed below are exported. These defaults also match the official k6 Dashboard for DataDog, which you can read more about on [visualization of metrics in DataDog](/results-visualization/datadog#visualize-in-datadog).
+The `metrics` parameter allows you to specify built-in and custom metrics to be exported to the APM provider. By default, only the basic [metrics](/using-k6/metrics) listed below are exported. These defaults also match the [official k6 dashboard for DataDog](https://docs.datadoghq.com/integrations/k6/), which you can read more about on [visualization of metrics in DataDog](/results-visualization/datadog#visualize-in-datadog).
 
 - data_sent
 - data_received
@@ -60,7 +61,8 @@ export let options = {
               api_key: "<DataDog Provided API key>",
               app_key: "<DataDog Provided App key>",
               metrics: ["http_req_sending", "my_rate", "my_gauge", ...],
-              include_default_metrics: true
+              include_default_metrics: true,
+              include_test_run_id: false
           },
       ]
     },
@@ -75,6 +77,7 @@ Make sure to meet the following requirements, otherwise we can't guarantee a wor
 3. If the APM configuration has errors, (e.g. invalid provider, wrong credentials, etc) the configuration will be ignored, and the test will be executed without the APM functionality.
 4. If you provide invalid metrics to the `metrics` field, the test will continue, but the metrics export(s) will not include the invalid metric.
 5. The metrics defined in `metrics` are case-sensitive.
+6. The [official k6 dashboard on DataDog](https://docs.datadoghq.com/integrations/k6/) gives you the ability to filter metrics based on `test_run_id`, but we don't export `test_run_id` as an extra tag by default. If you want to export it, you should set `include_test_run_id` to `true`.
 
 ## Limitations
 


### PR DESCRIPTION
In this guide, I have briefly explained how the feature works and how one can configure their load test to export metrics to their desired APM platform. For now, only DataDog (.com/.eu) is supported, but the plan is to add others.