### PR TITLE
Add per-URL data sent/recv example

### DIFF
--- a/src/data/markdown/docs/01 guides/02 Using k6/02 Metrics.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/02 Metrics.md
@@ -131,6 +131,53 @@ The value of `my_counter` will be 3 (if you run it one single iteration - i.e. w
 
 Note that there is currently no way of accessing the value of any custom metric from within JavaScript. Note also that counters that have value zero (`0`) at the end of a test are a special case - they will **NOT** be printed to the stdout summary.
 
+**Examples**
+
+*Traking data sent and received per-URL*:
+
+<div class="code-group" data-props='{"labels": ["per-url-data-sent-recv.js"], "lineNumbers": [true]}'>
+
+```js
+import http from "k6/http";
+import { sleep } from "k6";
+import { Counter } from "k6/metrics";
+
+// Two custom metrics to track data sent and received. We will tag data points added with the corresponding URL
+// so we can filter these metrics down to see the data for individual URLs and set threshold across all or per-URL as well.
+export let epDataSent = new Counter("endpoint_data_sent");
+export let epDataRecv = new Counter("endpoint_data_recv");
+
+export let options = {
+    stages: [
+        {target: 10, duration: "1m"}
+    ],
+    thresholds: {
+        // We can setup thresholds on these custom metrics, "count" means bytes in this case.
+        "endpoint_data_sent": ["count < 1024"],
+
+        // The above threshold would look at all data points added to the custom metric.
+        // If we want to only consider data points for a particular URL/endpoint we can filter by URL.
+        "endpoint_data_recv{url:https://test.k6.io/}": ["count < 2048"] // "count" means bytes in this case
+    }
+};
+
+function sizeOfHeaders(hdrs) {
+    return Object.keys(hdrs).reduce((sum, key) => sum + key.length + hdrs[key].length, 0);
+}
+
+export default function() {
+    let res = http.get("https://test.k6.io/");
+
+    // Add data points for sent and received data
+    epDataSent.add(sizeOfHeaders(res.request.headers) + res.request.body.length, { url: res.url });
+    epDataRecv.add(sizeOfHeaders(res.headers) + res.body.length, { url: res.url });
+
+    sleep(1);
+};
+```
+
+</div>
+
 ### Gauge _(keep the latest value only)_
 
 <div class="code-group" data-props='{"labels": ["gauge.js"], "lineNumbers": [true]}'>


### PR DESCRIPTION
This PR adds an example script to the `Counter` custom metric docs to show how to track data sent and received per-URL.

As discussed in Slack this was added in-context rather than as an example in the "Examples" section.