### PR TITLE
Update apt-key for linux installation

### DIFF
--- a/src/data/markdown/docs/01 guides/01 Getting started/02 Installation.md
+++ b/src/data/markdown/docs/01 guides/01 Getting started/02 Installation.md
@@ -2,16 +2,35 @@
 title: 'Installation'
 ---
 
-## Linux (deb and rpm packages)
+## Linux
 
-<div class="code-group" data-props='{ "labels": ["Linux (Debian/Ubuntu)", "Linux (Redhat/CentOS)"] }'>
+
+### Debian/Ubuntu
+
+<div class="code-group" data-props='{ "labels": [""] }'>
 
 ```shell
-wget -q -O - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
 echo "deb https://dl.bintray.com/loadimpact/deb stable main" | sudo tee -a /etc/apt/sources.list
 sudo apt-get update
 sudo apt-get install k6
 ```
+
+</div>
+
+> ### ⚠️ If you are behind a firewall or proxy
+>
+> There have been reports of users being unable to download the key from Ubuntu's keyserver using `apt-key`
+> command due to firewalls or proxies blocking their requests. If you experience this issue, you may try this
+> alternative approach instead:
+> 
+> ```
+> wget -q -O - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
+> ```
+
+### Redhat/CentOS
+
+<div class="code-group" data-props='{ "labels": [""] }'>
 
 ```shell
 wget https://bintray.com/loadimpact/rpm/rpm -O bintray-loadimpact-rpm.repo

--- a/src/data/markdown/docs/01 guides/01 Getting started/02 Installation.md
+++ b/src/data/markdown/docs/01 guides/01 Getting started/02 Installation.md
@@ -7,7 +7,7 @@ title: 'Installation'
 <div class="code-group" data-props='{ "labels": ["Linux (Debian/Ubuntu)", "Linux (Redhat/CentOS)"] }'>
 
 ```shell
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
+wget -q -O - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -
 echo "deb https://dl.bintray.com/loadimpact/deb stable main" | sudo tee -a /etc/apt/sources.list
 sudo apt-get update
 sudo apt-get install k6


### PR DESCRIPTION
The initial installation suggestion `wget -q -O - https://bintray.com/user/downloadSubjectPublicKey?username=bintray | sudo apt-key add -` is not suitable for trying to install behind firewalls. This was highly difficult when I was trying to make a docker image with k6 installed. I was able to get around this by following bintray suggestion from https://bintray.com/cublinux/deb.