### PR TITLE
Specify that http.batch actually returns array now

### DIFF
--- a/src/data/markdown/docs/02 javascript api/06 k6-http/10-batch- requests -.md
+++ b/src/data/markdown/docs/02 javascript api/06 k6-http/10-batch- requests -.md
@@ -16,7 +16,7 @@ When each request is specified as an array, the order of the arguments for each 
 
 | Type   | Description                                                                                                                                                                                                            |
 | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| object | An object containing [Response](/javascript-api/k6-http/response) objects.<br /><br />It has integer keys when users pass an array as `requests` and string keys when named requests are used (see below). |
+| object | An object containing [Response](/javascript-api/k6-http/response) objects.<br /><br />It is an array when users pass an array as `requests` and is a normal object with string keys when named requests are used (see below). |
 
 
 | Position | Name | Type | Description |


### PR DESCRIPTION
fixed in loadimpact/k6#1259