### PR TITLE
Correct the syntax of the "entry" webpack config

### DIFF
--- a/src/data/markdown/docs/01 guides/02 Using k6/07 Modules.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/07 Modules.md
@@ -149,7 +149,10 @@ const path = require('path');
 
 module.exports = {
   mode: 'production',
-  entry: [(login: './src/login.test.js'), (signup: './src/signup.test.js')],
+  entry: {
+    login: './src/login.test.js',
+    signup: './src/signup.test.js',
+  },
   output: {
     path: path.resolve(__dirname, 'dist'),
     libraryTarget: 'commonjs',


### PR DESCRIPTION
The provided webpack sample had invalid javascript in it. I've updated the example to match the syntax required per https://webpack.js.org/concepts/entry-points/