### PR TITLE
Fix cloud logs example image link

### DIFF
--- a/src/data/markdown/docs/03 cloud/02 Analyzing Results/11 Logs.md
+++ b/src/data/markdown/docs/03 cloud/02 Analyzing Results/11 Logs.md
@@ -47,7 +47,7 @@ You can find your API token in https://app.k6.io/account/api-token.
 
 The output should look similar to this:
 
-![Example output](/images/11-Cloug-Logs/cloud-logs-example-output.png)
+![Example output](/images/11-Cloud-Logs/cloud-logs-example-output.png)
 
 
 ## Fetching logs from the past


### PR DESCRIPTION
Currently the cloud logs example image is not shown:

![2020-09-17-132148_660x156_scrot](https://user-images.githubusercontent.com/1009277/93464335-4ceeac80-f8e9-11ea-8459-d3caddf7b19b.png)

https://k6.io/docs/cloud/analyzing-results/logs