### PR TITLE
Docs: mentions node version number supported

### DIFF
--- a/src/data/markdown/docs/01 guides/02 Using k6/13 Session recording - HAR support.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/13 Session recording - HAR support.md
@@ -70,7 +70,7 @@ The [har-to-k6 converter](https://github.com/loadimpact/har-to-k6) is a NodeJS t
 
 **Install the har-to-k6 converter**
 
-A prerequisite is to have installed NodeJS. To install the converter, you can use `npm`:
+A prerequisite is to have installed NodeJS (version >=11.0.0). To install the converter, you can use `npm`:
 
 ```bash
 $ npm install -g har-to-k6


### PR DESCRIPTION
If the correct version is not set, the process will silently fail unless the user has explicitly set `engine-strict` on their local `npm` configuration.
The errors are confusing, like `flatMap of undefined` or similar (related fix https://github.com/loadimpact/har-to-k6/pull/43/files)