### PR TITLE
Fixed typo in 03 Running k6 docs ✏️

### DIFF
--- a/src/data/markdown/docs/01 guides/01 Getting started/03 Running k6.md
+++ b/src/data/markdown/docs/01 guides/01 Getting started/03 Running k6.md
@@ -98,7 +98,7 @@ running. Code _outside_ of it is called "init code", and is run only once per VU
 ```javascript
 // init code
 
-export default function( {
+export default function() {
   // vu code
 }
 


### PR DESCRIPTION
A code example was missing a closing bracket.