### PR TITLE
Feat: fade out overlay for expandable code blocks

### DIFF
--- a/src/components/shared/code/code.js
+++ b/src/components/shared/code/code.js
@@ -42,7 +42,8 @@ const Code = ({ children, showLineNumbers, showHeightToggler }) => {
 
   let toggler = null;
   let containerStyles = {};
-  // if `height` isn't equla default height,
+  let overlayStyles = { height: 0 };
+  // if `height` isn't equal default height,
   // code blocks fits the height requirements
   // for toggler to be shown
   if (height !== DEFAULT_HEIGHT) {
@@ -53,6 +54,10 @@ const Code = ({ children, showLineNumbers, showHeightToggler }) => {
     );
     containerStyles = {
       maxHeight: isExpanded ? height : `${MAX_HEIGHT}px`,
+      overflowY: 'hidden',
+    };
+    overlayStyles = {
+      height: isExpanded ? 0 : undefined,
     };
   }
 
@@ -92,6 +97,7 @@ const Code = ({ children, showLineNumbers, showHeightToggler }) => {
           </pre>
         )}
       </Highlight>
+      <div className={styles.overlay} style={overlayStyles} />
       {toggler}
     </WithCopyButton>
   );

--- a/src/components/shared/code/code.module.scss
+++ b/src/components/shared/code/code.module.scss
@@ -4,6 +4,7 @@
   overflow-y: auto;
   text-align: left;
   transition: max-height 0.2s ease-in-out;
+  position: relative;
   @include no-scrollbars;
 }
 
@@ -125,4 +126,14 @@
       }
     }
   }
+}
+
+.overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 200px;
+  transition: height 0.2s ease-in-out;
+  background: linear-gradient(to bottom, transparent, $color-primary);
 }


### PR DESCRIPTION
**Describe the changes**
This PR brings fade-out overlay for expandable code blocks. 

⚠️ This feature disables previously accessible overlay in collapsed mode

**Steps to test:**
1. Pull the changes, run `npm run start`
2. Visit,for example, http://localhost:8000/test-types/load-testing with an expandable code block
3. Assure it has an overlay indeed, which gracefully rolls down if you click `expand` and vice versa
4. Assure regular code blocks has no overlay

**Screenshots**
<details>
<summary>Self-explanatory gif</summary>

![expand-collapse](https://user-images.githubusercontent.com/32940211/97334004-01db9800-189e-11eb-99db-d5a28e82eb1e.gif)

</details>


**Refs**
Closes [task in Notion](https://www.notion.so/pixelpoint/Add-gradient-to-the-bottom-of-collapsed-code-blocks-3079b5d745c94777aad845f13199bc82)