### PR TITLE
fix: algolia indexing

### DIFF
--- a/src/utils/algolia.js
+++ b/src/utils/algolia.js
@@ -17,7 +17,7 @@ const processMdxEntry = ({ children: [entry] }) => {
     fileAbsolutePath,
     mdxAST,
     objectID,
-    frontmatter: { title, redirect },
+    frontmatter: { title, redirect, slug: customSlug },
   } = entry;
   if (redirect) {
     // avoid pushing empty records
@@ -41,13 +41,15 @@ const processMdxEntry = ({ children: [entry] }) => {
     .slice(0, -1)
     .join('/');
   const path = `/${cutStrippedDirectory}/${title.replace(/\//g, '-')}`;
-  const slug = compose(
-    noTrailingSlash,
-    dedupePath,
-    removeGuidesAndRedirectWelcome,
-    unorderify,
-    slugify,
-  )(path);
+  const slug =
+    customSlug ||
+    compose(
+      noTrailingSlash,
+      dedupePath,
+      removeGuidesAndRedirectWelcome,
+      unorderify,
+      slugify,
+    )(path);
   const chunks = chunk(mdxAstToPlainText(mdxAST), 300);
   let pointer = chunks.length;
   const cache = new Array(pointer);
@@ -86,6 +88,7 @@ const docPagesQuery = `{
         frontmatter {
           title
           redirect
+          slug
         }
         mdxAST
         fileAbsolutePath


### PR DESCRIPTION
**Describe changes**
Put missing `slug` frontmatter field back into mdx entry processing pipeline.

**Screenshots**

<details>
<summary>Updated dev algolia indices</summary>

![image](https://user-images.githubusercontent.com/32940211/99224306-e7933b00-2807-11eb-83c1-ffb07f49b4d1.png)

</details>

**Steps to test**
Note, that for some reason the search box is absent in this autogenerated deploy preview below, so in order to check the changes you'll have to pull them locally and run `npm run start` or `npm run build && npm run serve`. This way you'll see updated `dev` indecis and the `prod` indecis will be updated accordingly after merging the changes into master


References: #149 Dead link