### PR TITLE
Node version strict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:10-slim
+FROM node:12-slim
 RUN apt-get update && apt-get install python build-essential -y
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ before retrying.
 
 ## Manual Installation
 
-This uses port `8000` by default.
+In node 12.x:
 
 ```bash
 git clone git@github.com:loadimpact/k6-docs.git

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "k6-docs",
+  "engines": {
+    "node": "12.x"
+  },
   "description": "",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
Should close #173 


Docker-componse uses nodejs 10.x
Github actions use nodejs 12.x


Locally, I've always worked with 10.x.

When testing, the following error came up:

```bash
k6-docs(master): node -v
v10.14.1
k6-docs(master): npm install
npm WARN deprecated core-js@2.6.12: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
npm ERR! code ENOTSUP
npm ERR! notsup Unsupported engine for gatsby-plugin-algolia@0.16.1: wanted: {"node":">=12.0.0"} (current: {"node":"10.14.1","npm":"6.4.1"})
npm ERR! notsup Not compatible with your version of node/npm: gatsby-plugin-algolia@0.16.1
npm ERR! notsup Not compatible with your version of node/npm: gatsby-plugin-algolia@0.16.1
npm ERR! notsup Required: {"node":">=12.0.0"}
npm ERR! notsup Actual:   {"npm":"6.4.1","node":"10.14.1"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/ppcano/.npm/_logs/2020-12-08T05_20_44_100Z-debug.log

```



