### PR TITLE
Update Cookie Docs - reference correct object name

### DIFF
--- a/src/data/markdown/docs/01 guides/02 Using k6/09 Cookies.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/09 Cookies.md
@@ -234,7 +234,7 @@ export default function () {
     'https://httpbin.org/cookies',
     'my_cookie',
     'hello world',
-    cookeOptions,
+    cookieOptions,
   );
 
   // Override per-VU jar with local jar for the following request


### PR DESCRIPTION
Update to reference `cookieOptions`