### PR TITLE
Advanced multipart request example + minor fixes

### DIFF
--- a/src/data/markdown/docs/02 javascript api/07 k6-http/10-file- data- -filename-- -contentType- -.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-http/10-file- data- -filename-- -contentType- -.md
@@ -3,7 +3,7 @@ title: 'file( data, [filename], [contentType] )'
 description: 'Create a file object that is used for building multi-part requests.'
 ---
 
-Create a file object that is used for building [Multipart requests (file uploads)](/using-k6/multipart-requests-file-uploads).
+Create a file object that is used for building [Multipart requests (file uploads)](/examples/data-uploads#multipart-request-uploading-a-file).
 
 | Parameter   | Type           | Description                                                                      |
 | ----------- | -------------- | -------------------------------------------------------------------------------- |

--- a/src/data/markdown/docs/02 javascript api/07 k6-http/60-FileData.md
+++ b/src/data/markdown/docs/02 javascript api/07 k6-http/60-FileData.md
@@ -3,7 +3,9 @@ title: 'FileData'
 description: 'Used for wrapping data representing a file when doing multipart requests (file uploads).'
 ---
 
-_FileData_ is an object for wrapping data representing a file when doing [multipart requests (file uploads)](/using-k6/multipart-requests-file-uploads). You create it by calling [http.file( data, [filename], [contentType] )](/javascript-api/k6-http/file-data-filename-contenttype).
+_FileData_ is an object for wrapping data representing a file when doing
+[multipart requests (file uploads)](/examples/data-uploads#multipart-request-uploading-a-file).
+You create it by calling [http.file( data, [filename], [contentType] )](/javascript-api/k6-http/file-data-filename-contenttype).
 
 | Name                  | Type           | Description                                                       |
 | --------------------- | -------------- | ----------------------------------------------------------------- |

--- a/src/data/markdown/docs/05 Examples/01 Examples/09 data-uploads.md
+++ b/src/data/markdown/docs/05 Examples/01 Examples/09 data-uploads.md
@@ -1,9 +1,9 @@
 ---
 title: 'Data Uploads'
-excerpt: 'Scripting examples on how to execute a load test that will upload a file to the System Under Test(SUT).'
+excerpt: 'Scripting examples on how to execute a load test that will upload a file to the System Under Test (SUT).'
 ---
 
-Example to execute a load test that will upload a file to the System Under Test(SUT).
+Example to execute a load test that will upload a file to the System Under Test (SUT).
 
 ## The open() function
 


### PR DESCRIPTION
Closes #203

We should merge https://github.com/loadimpact/jslib.k6.io/pull/21 and deploy first, otherwise the `FormData` links won't work.