### PR TITLE
Update 07 Logs Tab.md

### DIFF
--- a/src/data/markdown/docs/03 cloud/02 Analyzing Results/07 Logs Tab.md
+++ b/src/data/markdown/docs/03 cloud/02 Analyzing Results/07 Logs Tab.md
@@ -18,6 +18,8 @@ The k6 API supports the following console logging methods:
 - `console.warn()`
 - `console.error()`
 
+> **Note**: `console.debug()` will only log output when running k6 with the **`-v/--verbose`** flag.
+
 Logs can aid you in troubleshooting your test execution. But they should NOT replace the functionality of other k6 APIs.
 
 For example, it is often an **anti-pattern** to use `logs` to:

--- a/src/data/markdown/docs/03 cloud/02 Analyzing Results/07 Logs Tab.md
+++ b/src/data/markdown/docs/03 cloud/02 Analyzing Results/07 Logs Tab.md
@@ -18,7 +18,7 @@ The k6 API supports the following console logging methods:
 - `console.warn()`
 - `console.error()`
 
-> **Note**: `console.debug()` will only log output when running k6 with the **`-v/--verbose`** flag.
+> **Note**: `console.debug()` will only log output when running k6 with the `-v/--verbose` flag.
 
 Logs can aid you in troubleshooting your test execution. But they should NOT replace the functionality of other k6 APIs.
 


### PR DESCRIPTION
Added note about console.debug() only logging when k6 is launched with --verbose