### PR TITLE
Extend info about `group` with an antipattern section

### DIFF
--- a/src/data/markdown/docs/01 guides/02 Using k6/08 Tags and Groups.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/08 Tags and Groups.md
@@ -71,7 +71,7 @@ If your code looks like the example above, consider the following alternatives:
 - For dynamic URLs, use the [URL grouping feature](/using-k6/http-requests#url-grouping).
 - To provide a meaningful name to your request, set the value of [tags.name](/using-k6/http-requests#http-request-tags).
 - To reuse common logic or organize your code better, create a [local Javascript module](/using-k6/modules#local-filesystem-modules) and import it into the test script.
-
+- If you need to model advanced user patterns, check out [Scenarios](/using-k6/scenarios). 
 
 
 

--- a/src/data/markdown/docs/01 guides/02 Using k6/08 Tags and Groups.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/08 Tags and Groups.md
@@ -24,13 +24,14 @@ allowing you the BDD-style of testing.
 import { group } from 'k6';
 
 export default function () {
-  group('user flow: returning user', function () {
-    group('visit homepage', function () {
-      // load homepage resources
-    });
-    group('login', function () {
-      // perform login
-    });
+  group('add several products to the shopping cart', function () {
+    // ...
+  });
+  group('go to login and authenticate', function () {
+    // ...
+  });
+  group('checkout process', function () {
+    // ...
   });
 }
 ```
@@ -42,6 +43,37 @@ execution of the supplied `group()` function also emits a `group_duration`
 [metric](/using-k6/metrics) that contains the total time it took to execute that group
 function. This, combined with the metric tags described below, enables very flexible performance
 monitoring of different groups in your test suite.
+
+**Group anti-pattern**
+
+It is often an anti-pattern to wrap each individual request within a group.
+
+<CodeGroup labels={["group-antipattern.js"]} lineNumbers={[true]}>
+
+```javascript
+// reconsider this type of code
+group('get post', function () {
+   http.get(`http://example.com/posts/${id}`);
+});
+group('list posts', function () {
+   let res = http.get(`http://example.com/posts`);
+   check(res, {
+     'is status 200': (r) => r.status === 200,
+   });
+});
+```
+
+</CodeGroup>
+
+Groups were designed to help you visualize the various parts of a large test. 
+If your code looks like the example above, consider the following alternatives:
+
+- For dynamic URLs, use the [URL grouping feature](/using-k6/http-requests#url-grouping).
+- To provide a meaningful name to your request, set the value of [tags.name](/using-k6/http-requests#http-request-tags).
+- To reuse common logic or organize your code better, create a [local Javascript module](/using-k6/modules#local-filesystem-modules) and import it into the test script.
+
+
+
 
 ## Tags
 

--- a/src/data/markdown/docs/01 guides/02 Using k6/08 Tags and Groups.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/08 Tags and Groups.md
@@ -15,8 +15,10 @@ filter your test results.
 
 ## Groups
 
-Groups are optional, and it allows you to “group” your load script. Groups can be nested,
-allowing you the BDD-style of testing.
+
+Groups are optional, and it allows you to “group” a large load script to help you with the test result analysis. Groups can be nested, allowing you the BDD-style of testing.
+
+For example, you could use groups to organize multiple requests due to loading a page or executing a user action.
 
 <CodeGroup labels={["groups.js"]} lineNumbers={[true]}>
 
@@ -31,7 +33,10 @@ export default function () {
   group('add several products to the shopping cart', function () {
     // ...
   });
-  group('go to login page and authenticate', function () {
+  group('visit login page', function () {
+    // ...
+  });
+  group('authenticate', function () {
     // ...
   });
   group('checkout process', function () {
@@ -43,15 +48,17 @@ export default function () {
 
 </CodeGroup>
 
-Your test results will be grouped based on your group names for easy visualization. Each
-execution of the supplied `group()` function also emits a `group_duration`
-[metric](/using-k6/metrics) that contains the total time it took to execute that group
-function. This, combined with the metric tags described below, enables very flexible performance
-monitoring of different groups in your test suite.
+Groups do the following tasks internally:
+
+- For each `group()` function, k6 emits a [group_duration metric](/using-k6/metrics) that contains the total time to execute the group function. 
+
+- When a taggable resource: checks, requests, or custom metrics runs within a group, k6 will set the tag `group` with the current group name. Read more about it in [Tags](/using-k6/tags-and-groups#tags).
+
+Both options, the `group_duration` metric and `group tagging`, could help you analyze and visualize better the results of more complex tests. Check out how they work in your [k6 result output](/integrations#result-store-and-visualization).
 
 **Discouraged use cases**
 
-Be aware that wrapping each individual request within a group might add boilerplate code and be unnecessary.
+Wrapping each individual request within a group might add boilerplate code and be unnecessary.
 
 <CodeGroup labels={["group-antipattern.js"]} lineNumbers={[true]}>
 
@@ -70,7 +77,6 @@ group('list posts', function () {
 
 </CodeGroup>
 
-Groups were designed to help you visualize the various parts of a large test. 
 If your code looks like the example above, consider the following alternatives to write cleaner code:
 
 - For dynamic URLs, use the [URL grouping feature](/using-k6/http-requests#url-grouping).

--- a/src/data/markdown/docs/01 guides/02 Using k6/08 Tags and Groups.md
+++ b/src/data/markdown/docs/01 guides/02 Using k6/08 Tags and Groups.md
@@ -24,15 +24,20 @@ allowing you the BDD-style of testing.
 import { group } from 'k6';
 
 export default function () {
+
+  group('visit product listing page', function () {
+    // ...
+  });
   group('add several products to the shopping cart', function () {
     // ...
   });
-  group('go to login and authenticate', function () {
+  group('go to login page and authenticate', function () {
     // ...
   });
   group('checkout process', function () {
     // ...
   });
+
 }
 ```
 
@@ -44,9 +49,9 @@ execution of the supplied `group()` function also emits a `group_duration`
 function. This, combined with the metric tags described below, enables very flexible performance
 monitoring of different groups in your test suite.
 
-**Group anti-pattern**
+**Discouraged use cases**
 
-It is often an anti-pattern to wrap each individual request within a group.
+Be aware that wrapping each individual request within a group might add boilerplate code and be unnecessary.
 
 <CodeGroup labels={["group-antipattern.js"]} lineNumbers={[true]}>
 
@@ -66,11 +71,11 @@ group('list posts', function () {
 </CodeGroup>
 
 Groups were designed to help you visualize the various parts of a large test. 
-If your code looks like the example above, consider the following alternatives:
+If your code looks like the example above, consider the following alternatives to write cleaner code:
 
 - For dynamic URLs, use the [URL grouping feature](/using-k6/http-requests#url-grouping).
 - To provide a meaningful name to your request, set the value of [tags.name](/using-k6/http-requests#http-request-tags).
-- To reuse common logic or organize your code better, create a [local Javascript module](/using-k6/modules#local-filesystem-modules) and import it into the test script.
+- To reuse common logic or organize your code better, group logic in functions or create a [local Javascript module](/using-k6/modules#local-filesystem-modules) and import it into the test script.
 - If you need to model advanced user patterns, check out [Scenarios](/using-k6/scenarios). 
 
 

--- a/src/data/markdown/docs/02 javascript api/02 k6/group- name- fn -.md
+++ b/src/data/markdown/docs/02 javascript api/02 k6/group- name- fn -.md
@@ -24,15 +24,20 @@ Run code inside a group. Groups are used to organize results in a test.
 import { group } from 'k6';
 
 export default function () {
+
+  group('visit product listing page', function () {
+    // ...
+  });
   group('add several products to the shopping cart', function () {
     // ...
   });
-  group('go to login and authenticate', function () {
+  group('go to login page and authenticate', function () {
     // ...
   });
   group('checkout process', function () {
     // ...
   });
+
 }
 }
 ```

--- a/src/data/markdown/docs/02 javascript api/02 k6/group- name- fn -.md
+++ b/src/data/markdown/docs/02 javascript api/02 k6/group- name- fn -.md
@@ -31,7 +31,10 @@ export default function () {
   group('add several products to the shopping cart', function () {
     // ...
   });
-  group('go to login page and authenticate', function () {
+  group('visit login page', function () {
+    // ...
+  });
+  group('authenticate', function () {
     // ...
   });
   group('checkout process', function () {

--- a/src/data/markdown/docs/02 javascript api/02 k6/group- name- fn -.md
+++ b/src/data/markdown/docs/02 javascript api/02 k6/group- name- fn -.md
@@ -21,31 +21,26 @@ Run code inside a group. Groups are used to organize results in a test.
 <CodeGroup labels={[]}>
 
 ```javascript
-import { group, check } from 'k6';
-import http from 'k6/http';
+import { group } from 'k6';
 
 export default function () {
-  group('my user scenario', function () {
-    group('front page', function () {
-      let res = http.get('https://k6.io');
-      check(res, {
-        'status code is 200': (res) => res.status == 200,
-      });
-    });
-    group('features page', function () {
-      let res = http.get('https://k6.io/features');
-      check(res, {
-        'status code is 200': (res) => res.status == 200,
-        'h1 message is correct': (res) =>
-          res.html('h1').text().startsWith('Simple yet realistic load testing'),
-      });
-    });
+  group('add several products to the shopping cart', function () {
+    // ...
   });
+  group('go to login and authenticate', function () {
+    // ...
+  });
+  group('checkout process', function () {
+    // ...
+  });
+}
 }
 ```
 
 </CodeGroup>
 
-The above code will produce output like shown on the screenshot below,
-with check results presented separately depending on which group they were executed in:
-![](images/groups.png)
+The above code will present the results separately depending on the group execution.
+
+Learn more on [Groups and Tags](/using-k6/tags-and-groups).
+
+


### PR DESCRIPTION
Discourage the usage of `group` in some cases and provide alternatives. 